### PR TITLE
[#-008] Website header + minor library updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4407,11 +4407,6 @@
       "integrity": "sha1-0jM6NtnncXyK0vfKyv7HwytERmQ=",
       "dev": true
     },
-    "lodash.throttle": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
-    },
     "lodash.uniq": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -8271,14 +8266,6 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
       "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
       "dev": true
-    },
-    "v-media-query": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/v-media-query/-/v-media-query-1.0.3.tgz",
-      "integrity": "sha1-O/wDkZ4B//XSB3gwzD5ekrQD3fg=",
-      "requires": {
-        "lodash.throttle": "4.1.1"
-      }
     },
     "validate-npm-package-license": {
       "version": "3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8459,9 +8459,9 @@
       "dev": true
     },
     "vuetify": {
-      "version": "0.17.7",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-0.17.7.tgz",
-      "integrity": "sha512-Brk8dOeR/vkG4By5r2JXtS1jJojP3sFOtyTXtflH7aVPF+14Z0xBNO3nM4QuPgWofHi3pw/9maJZEbDVND7iNQ=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-1.0.1.tgz",
+      "integrity": "sha512-uh+7IGHHmjzORQe3ctW147kF+HIIUR9IVWw55njWxNSeZBzK/hdj1L3sZToIj/SeFX9WJ0tWt0mxdiW7gJoOow=="
     },
     "watchpack": {
       "version": "1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8459,9 +8459,9 @@
       "dev": true
     },
     "vuetify": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-0.17.6.tgz",
-      "integrity": "sha512-geIGnXjYEhUn1dr+g8FCFqvV6xUbALXNJ3UZQ32T0SJdGJh/JLsScINTxV+Pxt1F36s+YRnuFyHLiFOSnuVzjA=="
+      "version": "0.17.7",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-0.17.7.tgz",
+      "integrity": "sha512-Brk8dOeR/vkG4By5r2JXtS1jJojP3sFOtyTXtflH7aVPF+14Z0xBNO3nM4QuPgWofHi3pw/9maJZEbDVND7iNQ=="
     },
     "watchpack": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "v-media-query": "^1.0.3",
     "vue": "^2.4.2",
     "vue-router": "^2.7.0",
-    "vuetify": "^0.17.7"
+    "vuetify": "^1.0.1"
   },
   "devDependencies": {
     "babel-core": "^6.25.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "build": "cross-env NODE_ENV=production NODE_APP_MODE=app webpack --progress --hide-modules"
   },
   "dependencies": {
-    "v-media-query": "^1.0.3",
     "vue": "^2.4.2",
     "vue-router": "^2.7.0",
     "vuetify": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "v-media-query": "^1.0.3",
     "vue": "^2.4.2",
     "vue-router": "^2.7.0",
-    "vuetify": "^0.17.6"
+    "vuetify": "^0.17.7"
   },
   "devDependencies": {
     "babel-core": "^6.25.0",

--- a/src/assets/website-data.json
+++ b/src/assets/website-data.json
@@ -57,12 +57,27 @@
   },
   "headerLinks": {
     "left": [
-      { "address": "", "text": "",
-        "icon": { "name": "", "icon": ""}
+      { "address": "", "text": "LinkedIn",
+        "icon": { "name": "", "icon": "fab fa-linkedin"}
+      },
+      { "address": "", "text": "GitHub",
+        "icon": { "name": "", "icon": "fab fa-github-square"}
       }
     ],
     "right": [
-      { "address": "", "text": "",
+      { "address": "", "text": "Projects",
+        "icon": { "name": "", "icon": ""}
+      },
+      { "address": "", "text": "About",
+        "icon": { "name": "", "icon": ""}
+      },
+      { "address": "", "text": "Skillsets",
+        "icon": { "name": "", "icon": ""}
+      },
+      { "address": "", "text": "Contact",
+        "icon": { "name": "", "icon": ""}
+      },
+      { "address": "", "text": "Blog",
         "icon": { "name": "", "icon": ""}
       }
     ]

--- a/src/assets/website-data.json
+++ b/src/assets/website-data.json
@@ -57,11 +57,11 @@
   },
   "headerLinks": {
     "left": [
-      { "address": "", "text": "LinkedIn",
-        "icon": { "name": "", "icon": "fab fa-linkedin"}
+      { "address": "https://www.linkedin.com/in/robert-nill-096b64112/", "text": "LinkedIn",
+        "icon": { "name": "LinkedIn Icon", "icon": "fab fa-linkedin"}
       },
-      { "address": "", "text": "GitHub",
-        "icon": { "name": "", "icon": "fab fa-github-square"}
+      { "address": "https://github.com/rmnill202", "text": "GitHub",
+        "icon": { "name": "GitHub Icon", "icon": "fab fa-github-square"}
       }
     ],
     "right": [

--- a/src/js/App.vue
+++ b/src/js/App.vue
@@ -1,9 +1,10 @@
 <template>
   <div id="app">
-    <head> <!-- Include material icons -->
-      <link
-        href='https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Material+Icons'
-            rel="stylesheet">
+    <head>
+      <!-- Include Material icons -->
+      <link href='https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Material+Icons' rel="stylesheet">
+      <!-- Include Font Awesome icons -->
+      <link href="https://use.fontawesome.com/releases/v5.0.6/css/all.css" rel="stylesheet">
     </head>
     <body>
       <v-app> <!-- Required for Vuetify to work correctly -->
@@ -26,6 +27,5 @@
   -moz-osx-font-smoothing: grayscale;
   text-align: center;
   color: #2c3e50;
-  margin-top: 60px;
 }
 </style>

--- a/src/js/App.vue
+++ b/src/js/App.vue
@@ -1,6 +1,15 @@
 <template>
   <div id="app">
-    <router-view></router-view>
+    <head> <!-- Include material icons -->
+      <link
+        href='https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Material+Icons'
+            rel="stylesheet">
+    </head>
+    <body>
+      <v-app> <!-- Required for Vuetify to work correctly -->
+        <router-view></router-view>
+      </v-app>
+    </body>
   </div>
 </template>
 

--- a/src/js/components/header-nav.vue
+++ b/src/js/components/header-nav.vue
@@ -2,7 +2,7 @@
   <div>
     <v-toolbar flat dense>
       <!-- Icons on the left side of the toolbar -->
-      <v-btn icon v-for="link in leftLinks" :href="link.address">
+      <v-btn icon v-for="link in leftLinks" :href="link.address" class="hidden-xs-only">
         <v-icon>{{link.icon.icon}}</v-icon>
       </v-btn>
 
@@ -14,12 +14,18 @@
       </v-toolbar-items>
 
       <!-- For smaller screens, display a menu -->
-      <v-menu transition="slide-x-transition" class="hidden-md-and-up">
+      <v-menu transition="slide-x-transition" class="hidden-md-and-up" left>
         <!-- Hamburger menu icon! -->
         <v-btn icon slot="activator"> <v-icon>menu</v-icon> </v-btn>
         <!-- The menu contents -->
         <v-list>
-          <v-list-tile @click="" v-for="link in rightLinks">
+          <!-- Buttons from the right side of the toolbar -->
+          <v-list-tile @click="" v-for="link in rightLinks" :href="link.address">
+            <v-list-tile-title> {{link.text}} </v-list-tile-title>
+          </v-list-tile>
+          <!-- Links from the left side of the toolbar -->
+          <v-divider class="hidden-sm-and-up"></v-divider>
+          <v-list-tile @click="" v-for="link in leftLinks" :href="link.address" class="hidden-sm-and-up">
             <v-list-tile-title> {{link.text}} </v-list-tile-title>
           </v-list-tile>
         </v-list>

--- a/src/js/components/header-nav.vue
+++ b/src/js/components/header-nav.vue
@@ -1,6 +1,32 @@
 <template>
   <div>
-    <v-toolbar fixed color="blue" light dense></v-toolbar>
+    <v-toolbar flat dense>
+      <v-btn icon v-for="link in leftLinks">
+        <v-icon>{{link.icon.icon}}</v-icon>
+      </v-btn>
+
+      <v-spacer></v-spacer>
+
+      <!-- For larger screens -->
+      <v-toolbar-items class="hidden-sm-and-down">
+        <v-btn v-for="link in rightLinks" flat>{{link.text}}</v-btn>
+      </v-toolbar-items>
+
+      <!-- For smaller screens -->
+      <v-menu transition="slide-x-transition" class="hidden-md-and-up">
+
+        <!-- Hamburger menu icon! -->
+        <v-btn icon slot="activator"> <v-icon>menu</v-icon> </v-btn>
+
+        <!-- The menu contents -->
+        <v-list>
+          <v-list-tile @click="" v-for="link in rightLinks">
+            <v-list-tile-title> {{link.text}} </v-list-tile-title>
+          </v-list-tile>
+        </v-list>
+      </v-menu>
+
+    </v-toolbar>
   </div>
 </template>
 
@@ -10,7 +36,8 @@
     props: ['headerLinks'],
     data() {
       return {
-
+        leftLinks: this.headerLinks.left,
+        rightLinks: this.headerLinks.right
       };
     },
   };

--- a/src/js/components/header-nav.vue
+++ b/src/js/components/header-nav.vue
@@ -2,7 +2,7 @@
   <div>
     <v-toolbar flat dense>
       <!-- Icons on the left side of the toolbar -->
-      <v-btn icon v-for="link in leftLinks" :href="link.address" class="hidden-xs-only">
+      <v-btn icon v-for="link in leftLinks" :href="link.address" target="_blank" class="hidden-xs-only">
         <v-icon>{{link.icon.icon}}</v-icon>
       </v-btn>
 
@@ -25,7 +25,7 @@
           </v-list-tile>
           <!-- Links from the left side of the toolbar -->
           <v-divider class="hidden-sm-and-up"></v-divider>
-          <v-list-tile @click="" v-for="link in leftLinks" :href="link.address" class="hidden-sm-and-up">
+          <v-list-tile @click="" v-for="link in leftLinks" :href="link.address" target="_blank" class="hidden-sm-and-up">
             <v-list-tile-title> {{link.text}} </v-list-tile-title>
           </v-list-tile>
         </v-list>

--- a/src/js/components/header-nav.vue
+++ b/src/js/components/header-nav.vue
@@ -1,23 +1,22 @@
 <template>
   <div>
     <v-toolbar flat dense>
-      <v-btn icon v-for="link in leftLinks">
+      <!-- Icons on the left side of the toolbar -->
+      <v-btn icon v-for="link in leftLinks" :href="link.address">
         <v-icon>{{link.icon.icon}}</v-icon>
       </v-btn>
 
       <v-spacer></v-spacer>
 
-      <!-- For larger screens -->
+      <!-- For larger screens, display all buttons -->
       <v-toolbar-items class="hidden-sm-and-down">
         <v-btn v-for="link in rightLinks" flat>{{link.text}}</v-btn>
       </v-toolbar-items>
 
-      <!-- For smaller screens -->
+      <!-- For smaller screens, display a menu -->
       <v-menu transition="slide-x-transition" class="hidden-md-and-up">
-
         <!-- Hamburger menu icon! -->
         <v-btn icon slot="activator"> <v-icon>menu</v-icon> </v-btn>
-
         <!-- The menu contents -->
         <v-list>
           <v-list-tile @click="" v-for="link in rightLinks">
@@ -25,7 +24,6 @@
           </v-list-tile>
         </v-list>
       </v-menu>
-
     </v-toolbar>
   </div>
 </template>

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -9,7 +9,6 @@ Vue.config.productionTip = false;
 
 Vue.use(Vuetify);
 import 'vuetify/dist/vuetify.min.css';
-import 'vuetify/dist/vuetify.min.js';
 
 /* eslint-disable no-new */
 new Vue({

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -4,7 +4,6 @@
   -moz-osx-font-smoothing: grayscale;
   text-align: center;
   color: #2c3e50;
-  margin-top: 60px;
 }
 
 h1, h2 {


### PR DESCRIPTION
## Trello Ticket
https://trello.com/c/KIFxyoxz/8-008-website-header

## Summary
The initial toolbar/navbar/header/thing has been added to the top of the website! I focused mostly on the layout of visual elements with this PR. I'll probably fine tune how everything looks later on. 

### Example with a larger screen size
![image](https://user-images.githubusercontent.com/16766015/36395801-07bbe510-1589-11e8-8b8d-f42af38b9f34.png)
- On the left side of the toolbar, I have some external links that open up in new tabs and lead to my GitHub and LinkedIn pages. 
- On the right side of the toolbar are some navigation buttons that will end up linking to specific parts of the page, as well as a blog page which will still live on this website. So the primary distinction between these buttons and the icons is whether or not an external site is linked to.

### Example with a smaller screen size
![image](https://user-images.githubusercontent.com/16766015/36395910-90990eda-1589-11e8-9622-913cdfabe02c.png)
- For small screens, the buttons on the right side of the toolbar will be condensed down into a hamburger menu. The icons stick around until about ~600 px, or [whatever value is defined for `xs` in the Vuetify documentation](https://vuetifyjs.com/en/layout/display).

### Example with an itsy bitsy screen
![image](https://user-images.githubusercontent.com/16766015/36395999-f58cf7fc-1589-11e8-975d-fa3d80e98d8a.png)
- The icon links will end up being added to the hamburger menu once they disappear.

## Minor Changes
- Removed `v-media-query-, since [Vuetify has built in breakpoints](https://vuetifyjs.com/en/layout/display).
- Updated Vuetify to v1.0.1
- Updated some of the website data
- Removed the margin at the top of the page
- Wrapped everything with the `<v-app>` HTML element, which is required for Vuetify to work correctly