### PR TITLE
[#-010] "About Me" Section

### DIFF
--- a/src/assets/website-data.json
+++ b/src/assets/website-data.json
@@ -116,66 +116,87 @@
   "about": [
     {
       "name": "Software",
-      "description": "TO DO",
+      "description": "I'm a software engineer!",
+      "icon": "fas fa-code",
       "image": {
         "name": "TO DO",
-        "img": "TO DO"
-        },
-      "bulletPoints": [
-        {"text": "TO DO"},
-        {"text": "TO DO"},
-        {"text": "TO DO"}
+        "img": "gradient.png"
+      },
+      "gallery": [
+        {"img": "gradient.png", "text": "A"},
+        {"img": "gradient.png", "text": "B"},
+        {"img": "gradient.png", "text": "C"}
       ]
     },
     {
       "name": "Music",
-      "description": "TO DO",
+      "description": "Stuff I listen to",
       "icon": "fas fa-headphones",
-      "bulletPoints": [
-        {"text": "TO DO"}
+      "image": {
+        "name": "TO DO",
+        "img": "gradient.png"
+      },
+      "gallery": [
+        {"img": "gradient.png", "text": "A"},
+        {"img": "gradient.png", "text": "B"},
+        {"img": "gradient.png", "text": "C"}
       ]
 	  },
     {
       "name": "Games",
-      "description": "TO DO",
+      "description": "Games I play",
+      "icon": "fas fa-gamepad",
       "image": {
         "name": "TO DO",
-        "img": "TO DO"
-        },
-      "icon": "fas fa-gamepad",
-      "bulletPoints": [
-        {"text": "TO DO"}
+        "img": "gradient.png"
+      },
+      "gallery": [
+        {"img": "gradient.png", "text": "A"},
+        {"img": "gradient.png", "text": "B"},
+        {"img": "gradient.png", "text": "C"}
       ]
 	  },
     {
       "name": "UX",
-      "description": "TO DO",
+      "description": "Cool experiences",
+      "icon": "fas fa-user",
       "image": {
         "name": "TO DO",
-        "img": "TO DO"
-        },
-      "bulletPoints": [
-        {"text": "TO DO"}
+        "img": "gradient.png"
+      },
+      "gallery": [
+        {"img": "gradient.png", "text": "A"},
+        {"img": "gradient.png", "text": "B"},
+        {"img": "gradient.png", "text": "C"}
       ]
 	  },
     {
       "name": "3D Printing",
-      "description": "TO DO",
+      "description": "Fun hobby",
+      "icon": "fas fa-cubes",
       "image": {
         "name": "TO DO",
-        "img": "TO DO"
-        },
-      "bulletPoints": [
-        {"text": "TO DO"}
+        "img": "gradient.png"
+      },
+      "gallery": [
+        {"img": "gradient.png", "text": "A"},
+        {"img": "gradient.png", "text": "B"},
+        {"img": "gradient.png", "text": "C"}
       ]
 	  }
   ],
   "skillsets": [
-    { "name": "Title", "description": "Description",
+    {
+      "name": "Software",
+      "description": "I'm a software engineer",
+      "icon": "fas fa-code",
       "image": {
-        "name": "An image!",
-        "img": "/"
-      }
+        "name": "TO DO",
+        "img": "TO DO"
+      },
+      "gallery": [
+        {"img": "", "text": "Stuff"}
+      ]
     }
   ],
   "contactInfo": {

--- a/src/js/components/about.vue
+++ b/src/js/components/about.vue
@@ -8,7 +8,7 @@
       <v-layout row wrap>
 
         <v-flex v-for="item in about">
-          <list-card :value="item" :img-width="'60px'" :width="'250px'"></list-card>
+          <list-card :value="item" :img-width="'60px'" :gallery-width="'70px'" :width="'250px'"></list-card>
         </v-flex>
 
       </v-layout>

--- a/src/js/components/util/list-card.vue
+++ b/src/js/components/util/list-card.vue
@@ -1,25 +1,42 @@
 <template>
   <v-card :style="cardStyle" class="cardStyle">
+
     <!-- Title -->
     <v-card-title class="title">
       <!-- Optional Image or Icon; prefer images -->
-      <img v-if="value.image" src="../../../assets/gradient.png" class="optionalImage" :style="imgStyle"/>
-      <v-icon v-else-if="value.icon" class="optionalIcon">{{value.icon}}</v-icon>
+      <div class="imgcontainer">
+        <img v-if="value.image" :src="getSrc(value.image)" class="optionalImage" :style="imgStyle"/>
+        <v-icon v-if="value.icon && value.image" class="iconWithImage">{{value.icon}}</v-icon>
+        <v-icon v-else-if="value.icon" class="optionalIcon">{{value.icon}}</v-icon>
+      </div>
+      
       
       <div class="name"> {{value.name}} </div>
     </v-card-title>
 
     <!-- Description -->
-    <v-card-text>
+    <v-card-text style="padding-top: 0">
       <span>{{value.description}}</span>
 
+      <!-- Bullet Points -->
       <div v-for="point in value.bulletPoints">
         {{point.text}}
       </div>
+
+      <!-- Gallery -->
+      <v-container v-if="value.gallery" grid-list-xs style="margin-top: 16px">
+        <v-layout row wrap>
+          <v-flex style="padding: 2px" v-for="item in value.gallery">
+            <v-card flat>
+               <v-tooltip bottom>
+                <img :src="getSrc(item)" slot="activator" class="galleryImage" :style="galleryStyle"/>
+                <span>{{item.text}}</span> <!-- Tooltip text -->
+              </v-tooltip>
+            </v-card>
+          </v-flex>
+        </v-layout>
+      </v-container>
     </v-card-text>
-
-    <!-- Bullet Points -->
-
 
   </v-card>
 </template>
@@ -27,7 +44,7 @@
 <script>
   export default {
     name: 'list-card',
-    props: ['value', 'imgWidth', 'width'],
+    props: ['value', 'imgWidth', 'width', 'galleryWidth'],
     data() {
       return {
       };
@@ -42,6 +59,14 @@
         if(this.width) {
           return {'width': this.width};
         }
+      },
+      galleryStyle() {
+        return this.galleryWidth ? {'width': this.galleryWidth} : this.imgStyle;
+      }
+    },
+    methods: {
+      getSrc(item) {
+        return require(`../../../assets/${item.img}`);
       }
     }
   }
@@ -56,19 +81,32 @@
     -webkit-clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
     clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
     display: block;
-    margin-left: auto;
-    margin-right: auto;
-    margin-bottom: 10px;
   }
   .optionalIcon {
     display: block;
-    margin-left: auto;
-    margin-right: auto;
-    margin-bottom: 10px;
     font-size: 53px;
   }
   .cardStyle {
     margin-left: auto;
     margin-right: auto;
+  }
+  .imgcontainer {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 10px;
+  }
+  .iconWithImage {
+    display: block;
+    font-size: 53px;
+    position: absolute;
+    transform: translate(-50%, -106%);
+  }
+  .galleryImage {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    width: 100%;
+    height: 100%;
   }
 </style>


### PR DESCRIPTION
## Trello Ticket
https://trello.com/c/CzhRDu7T/11-011-main-page-about-section-component

## Summary
Much less work than the projects section, with some minor differences from the original wireframe. Here's a list of some of the major changes.
- Added a `list-card` component, also for use in the "Skillsets" section of the website
- Added some kind-of-real-data for the "About Me" section

## List Card
Here's an example of a the card that I'll be using for the **About Me** and **Skillsets** section.
![image](https://user-images.githubusercontent.com/16766015/38782369-63494348-40c0-11e8-9aaa-55bb7014af10.png)
- Those little images at the bottom make up a **gallery**, and each one has it's own tooltip for additional details. 
- I've got the images/icons overlapping at the top, which looks really cool! Though it's hardcoded for the current icon/image sizes. Not too concerned about it right now, as I can avoid the issue by only having an icon or an image (rather than both).

## About Me (Large Screen)
![image](https://user-images.githubusercontent.com/16766015/38782391-b9720002-40c0-11e8-8baa-8e4ffd0b47d2.png)

## About Me (Medium Screen)
![image](https://user-images.githubusercontent.com/16766015/38782396-c69c9ecc-40c0-11e8-85cc-81158c771149.png)

## About Me (Smaller Screen)
![image](https://user-images.githubusercontent.com/16766015/38782399-d0a51994-40c0-11e8-8989-e7a6b620be92.png)

## Action Items
- Refactor hard-coded icon/image overlap, if necessary
- Using real images/data for the **About Me** section